### PR TITLE
Add a warning for nonparsable statements to match fitch

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -93,7 +93,7 @@
   position: relative;
 }
 
-.truth-tree i.fas.fa-check, .truth-tree i.fas.fa-times {
+.truth-tree i.fas.fa-check, .truth-tree i.fas.fa-times, .truth-tree i.fas.fa-exclamation-triangle {
   position: absolute;
   top: 50%;
   left: -30px;
@@ -106,6 +106,10 @@
 
 .truth-tree i.fas.fa-times {
   color: #c08080;
+}
+
+.truth-tree i.fas.fa-exclamation-triangle {
+  color: #bdbc58;
 }
 
 .selected {

--- a/src/client/component/truth-tree-node.ts
+++ b/src/client/component/truth-tree-node.ts
@@ -9,10 +9,19 @@ export const TruthTreeNodeComponent: vue.Component = {
 		node() {
 			return this.$store.state.tree.nodes[this.id];
 		},
+		parsable():string {
+			for(const value of <[string]>Object.values(this.node.isValid())){
+				if(value.endsWith("is not a parsable statement.")){
+					return value.split(': ')[1];
+				}
+			}
+			return "";
+		}
 	},
 	template: `
     <span v-if="$store.state.developerMode">id: {{ id }} valid: {{ JSON.stringify(node.isValid()) }} decomposed: {{ JSON.stringify(node.isDecomposed()) }} universe: {{ JSON.stringify(Array.from(node.universe).map(formula => formula.toString()) ) }} </span>
-    <i v-if="Object.keys(node.isValid()).length === 0 && Object.keys(node.isDecomposed()).length === 0" class="fas fa-check"></i>
+    <i v-if="parsable !== ''" class="fas fa-exclamation-triangle" :title="parsable"></i>
+    <i v-else-if="Object.keys(node.isValid()).length === 0 && Object.keys(node.isDecomposed()).length === 0" class="fas fa-check"></i>
     <i v-else class="fas fa-times"></i>
     <input :id='"node" + this.id' type="text" v-model="node.text" :class="{
       'statement': true,


### PR DESCRIPTION
Fitch has a way to know if a statement is wrong, or if the statement is just not parsable. Willow has the code to check if it is not parsable, but it was not being displayed to the user. This allows the user to see that their logic statement is invalid and fix it.

![image](https://user-images.githubusercontent.com/18558130/116008362-25c82e00-a5e2-11eb-8e8b-b6d8147650bc.png)
